### PR TITLE
fix mcp not reading channel 8

### DIFF
--- a/src/mcp.h
+++ b/src/mcp.h
@@ -15,7 +15,7 @@
 
 enum MCP_DESC {
 	MCP3002 = 2,
-	MCP3008 = 7
+	MCP3008 = 8
 };
 
 class MCP {


### PR DESCRIPTION
the MCP_DESC enum was set to 7 for MCP3008 so wasn't reading the last channel. :)