### PR TITLE
using ofColor instead of ofVec3f for LED pixels

### DIFF
--- a/example-apa102-ledstrip/src/main.cpp
+++ b/example-apa102-ledstrip/src/main.cpp
@@ -6,14 +6,14 @@ class ofApp : public ofBaseApp
 {
         public:
 		LED apa;
-		vector<ofVec3f> colors;
+		vector<ofColor> colors;
 		int numLed;
 		int brightness;
     
         void create_palett()
         {
             for(int i = 0; i < numLed; i++) {
-                colors.push_back(ofVec3f(
+                colors.push_back(ofColor(
                                          (int)ofRandom(0,255),
                                          (int)ofRandom(0,255),
                                          (int)ofRandom(0,255)
@@ -24,7 +24,7 @@ class ofApp : public ofBaseApp
         void gen_palett()
         {
             for(int i = 0; i < numLed; i++) {
-                colors[i] = ofVec3f(
+                colors[i] = ofColor(
                               (int)ofRandom(0,255),
                               (int)ofRandom(0,255),
                               (int)ofRandom(0,255)
@@ -42,8 +42,11 @@ class ofApp : public ofBaseApp
 
 		void update(){
 			gen_palett();
-			apa.setAPA102(numLed,colors,5);
-			usleep(1000);
+			apa.setAPA102(numLed,colors,brightness);
+			usleep(100000);
+            //cycling from blackout up to max brightness
+            if(brightness<31) brightness++;
+            else brightness=0;
 		}
 		
 		void exit(){

--- a/src/led.h
+++ b/src/led.h
@@ -34,13 +34,13 @@ class LED {
 		}
 	}
 
-	void setAPA102(int numLed, vector<ofVec3f> colors, int BRIGHTNESS){
+	void setAPA102(int numLed, vector<ofColor> colors, int BRIGHTNESS){
 		int a;
                 uint8_t buffer0[1], buffer1[4];
                 srand(time(NULL));
 		xnumLed = numLed;
-		if(BRIGHTNESS>29)
-			BRIGHTNESS=30;
+		if(BRIGHTNESS>30)
+			BRIGHTNESS=31;
 
                 for(a=0; a<4; a++){
                        buffer0[0]=0x00;//0b00000000;
@@ -49,9 +49,9 @@ class LED {
                 }
                 for(a=0; a<numLed; a++){
                        buffer1[0]=0b11100000 | (0b00011111 & BRIGHTNESS);//(BRIGHTNESS & 0b00011111) | 0b11100000;
-                       buffer1[1]=static_cast<uint8_t>(colors[a].z);  //blue
-                       buffer1[2]=static_cast<uint8_t>(colors[a].y);  //green
-                       buffer1[3]=static_cast<uint8_t>(colors[a].x);  //red
+                       buffer1[1]=static_cast<uint8_t>(colors[a].b);  //blue
+                       buffer1[2]=static_cast<uint8_t>(colors[a].g);  //green
+                       buffer1[3]=static_cast<uint8_t>(colors[a].r);  //red
                        if( spi.readWrite(channel, (unsigned char*)buffer1, 4) == -1)
 		       	std::cout << "Error: SPI RGB data failed!" << std::endl;
                 }

--- a/src/led.h
+++ b/src/led.h
@@ -39,8 +39,8 @@ class LED {
                 uint8_t buffer0[1], buffer1[4];
                 srand(time(NULL));
 		xnumLed = numLed;
-		if(BRIGHTNESS>29)
-			BRIGHTNESS=30;
+		if(BRIGHTNESS>30)
+			BRIGHTNESS=31;
 
                 for(a=0; a<4; a++){
                        buffer0[0]=0x00;//0b00000000;


### PR DESCRIPTION
I'm not sure at all you'd want to merge this pull request because it breaks backward compatibility 

so, since there is a native, char-based type for colors, it seemed more logical to use it... 
what do you think ?

 if you think the change is worth it, I could add support for converting ofVec3f into ofColor so backward compatibility is not broken, for the cost of some extra conversion...

if you don't think that's worth, feel free to reject the PR

cheers!
